### PR TITLE
Fix typo Update CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -354,7 +354,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 ### Improvements
 
 * (27-interchain-accounts) [\#1352](https://github.com/cosmos/ibc-go/pull/1352) Add support for Cosmos-SDK simulation to ics27 module.  
-* (linting) [\#1418](https://github.com/cosmos/ibc-go/pull/1418) Fix linting errors, resulting compatiblity with go1.18 linting style, golangci-lint 1.46.2 and the revivie linter.  This caused breaking changes in core/04-channel, core/ante, and the testing library.
+* (linting) [\#1418](https://github.com/cosmos/ibc-go/pull/1418) Fix linting errors, resulting compatibility with go1.18 linting style, golangci-lint 1.46.2 and the revivie linter.  This caused breaking changes in core/04-channel, core/ante, and the testing library.
 
 ### Features
 


### PR DESCRIPTION
# Pull Request: Fix Typo in `CHANGELOG.md`

## Description

This PR addresses a typo in the `CHANGELOG.md` file:
- Corrected `compatiblity` to `compatibility`.

### Changes
- **File:** `CHANGELOG.md`
- **Changes:**
  - Line 354: Updated the spelling of `compatiblity` to `compatibility`.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated changelog to clarify linting fixes compatibility with Go 1.18
  - Added support for benchmarks and fuzz tests documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->